### PR TITLE
lib: spdm: improve GET_CAPABILITIES conformance

### DIFF
--- a/lib/spdm_requester.c
+++ b/lib/spdm_requester.c
@@ -701,6 +701,9 @@ static int spdm_get_capabilities(struct spdm_state *spdm_state,
 		rsp_sz = sizeof(*rsp);
 		req->data_transfer_size = cpu_to_le32(spdm_state->transport_sz);
 		req->max_spdm_msg_size = cpu_to_le32(UINT_MAX);
+
+		if (!(req->flags & SPDM_CHUNK_CAP))
+			req->max_spdm_msg_size = req->data_transfer_size;
 	}
 
 	rsp = (void *)req + req_sz;


### PR DESCRIPTION
SPDM specification version 1.3 specifies that for a `GET_CAPABILITIES`
request, the `DataTransferSize` should equal `MaxSPDMmsgSize`, when
chunking is not used/supported.
    
This is **not** specified in the 1.2 specification **currently**, but a
clarification is to be added to specification 1.2.2 [1]. This patch
adds conformance to this clarification.
    
[1] https://github.com/DMTF/libspdm/pull/2329#issuecomment-1698238678